### PR TITLE
Adjusting Damping Example

### DIFF
--- a/SONATA/utl/converter_WT.py
+++ b/SONATA/utl/converter_WT.py
@@ -420,9 +420,8 @@ def converter_WT(blade, cs_pos, byml, materials, mesh_resolution):
 
         if x[i] > span_adhesive and len(tmp2[i]['segments']) > 1:
             # id_seg = n_webs*2 + 2            
-            assert 'Adhesive' in [materials[mat].name for mat in materials], \
-                'Adhesive material needs to be included for TE fill.' \
-                + ' Name needs to be exactly `Adhesive`.'
+            assert 'ADHESIVE' in [materials[mat].name.upper() for mat in materials], \
+                'Adhesive material needs to be included for TE fill.'
             
             tmp2[i]['segments'][-1]['filler'] = 'Adhesive'
             tmp2[i]['segments'][-1]['layup'][0]['name'] = 'dummy'

--- a/SONATA/utl/converter_WT.py
+++ b/SONATA/utl/converter_WT.py
@@ -419,7 +419,11 @@ def converter_WT(blade, cs_pos, byml, materials, mesh_resolution):
                                     web_filler_index = False  #  after completing the te part (this web is finished now!), prepare for next web
 
         if x[i] > span_adhesive and len(tmp2[i]['segments']) > 1:
-            # id_seg = n_webs*2 + 2
+            # id_seg = n_webs*2 + 2            
+            assert 'Adhesive' in [materials[mat].name for mat in materials], \
+                'Adhesive material needs to be included for TE fill.' \
+                + ' Name needs to be exactly `Adhesive`.'
+            
             tmp2[i]['segments'][-1]['filler'] = 'Adhesive'
             tmp2[i]['segments'][-1]['layup'][0]['name'] = 'dummy'
             tmp2[i]['segments'][-1]['layup'][0]['material_name'] = 'Adhesive'


### PR DESCRIPTION
Function call order rearrangement to match initial plans so should support zero twist output for sections. 

Added the `flag_output_zero_twist` flag to the example.

To Do:
1. Include/move the stress maps output in the main `beam_struct_eval` call.
2. Run the IEA 22 MW and strain energies calculations with both `True` and `False` for `flag_output_zero_twist`. Verify that the results are consistent.